### PR TITLE
ci: pin ubuntu-latest to ubuntu-24.04

### DIFF
--- a/.github/workflows/nightly.yml
+++ b/.github/workflows/nightly.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   nightly:
     name: Nightly Build and Integration Tests
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     if: github.repository == 'redhat-best-practices-for-k8s/perfdive'
     steps:
       - name: Checkout code

--- a/.github/workflows/pre-main.yml
+++ b/.github/workflows/pre-main.yml
@@ -9,7 +9,7 @@ permissions: read-all
 jobs:
   lint:
     name: Lint
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6
@@ -27,7 +27,7 @@ jobs:
 
   test:
     name: Test
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-24.04
     steps:
       - name: Checkout code
         uses: actions/checkout@v6


### PR DESCRIPTION
## Summary
- Pin `ubuntu-latest` to `ubuntu-24.04` in all GitHub Actions workflows

Prevents unexpected behavior changes when GitHub updates the `ubuntu-latest` label.
Tracked by [CNFCERT-1419](https://redhat.atlassian.net/browse/CNFCERT-1419).